### PR TITLE
Fix timer GUI display and alert UID bugs

### DIFF
--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -1275,6 +1275,46 @@ class TestAlertManager(unittest.TestCase):
 
     # TODO: Test Snooze Alert
 
+    def test_timer_gui(self):
+        manager = self._init_alert_manager()
+
+        now_time = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+        timer_1_time = now_time + dt.timedelta(minutes=5)
+        timer_1_name = '5 minute timer'
+        timer_1 = Alert.create(timer_1_time, timer_1_name, AlertType.TIMER)
+
+        # Add timer to GUI
+        manager.add_timer_to_gui(timer_1)
+        self.assertEqual(len(manager.active_gui_timers), 1)
+        self.assertEqual(manager.active_gui_timers[0].data, timer_1.data)
+
+        # Ignore adding duplicate timer to GUI
+        manager.add_timer_to_gui(timer_1)
+        self.assertEqual(len(manager.active_gui_timers), 1)
+        self.assertEqual(manager.active_gui_timers[0].data, timer_1.data)
+
+        # Add different timer at same time
+        timer_2 = Alert.create(timer_1_time, 'timer 2', AlertType.TIMER)
+        manager.add_timer_to_gui(timer_2)
+        self.assertEqual(len(manager.active_gui_timers), 2)
+        self.assertIn(manager.active_gui_timers[0].data,
+                      (timer_1.data, timer_2.data))
+        self.assertIn(manager.active_gui_timers[1].data,
+                      (timer_1.data, timer_2.data))
+
+        # Dismiss timer
+        manager.dismiss_alert_from_gui(get_alert_id(timer_2))
+        self.assertEqual(len(manager.active_gui_timers), 1)
+        self.assertEqual(manager.active_gui_timers[0].data, timer_1.data)
+
+        # Add timer with the same name at a later time
+        timer_3_time = now_time + dt.timedelta(minutes=6)
+        timer_3 = Alert.create(timer_3_time, timer_1_name, AlertType.TIMER)
+        manager.add_timer_to_gui(timer_3)
+        self.assertEqual(len(manager.active_gui_timers), 2)
+        self.assertEqual(manager.active_gui_timers[0].data, timer_1.data)
+        self.assertEqual(manager.active_gui_timers[1].data, timer_3.data)
+
 
 class TestParseUtils(unittest.TestCase):
     def test_round_nearest_minute(self):

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -1805,9 +1805,10 @@ class TestParseUtils(unittest.TestCase):
 
         local_user = parse_alert_context_from_message(test_message_local_user)
         self.assertEqual(local_user["user"], "local")
-        self.assertEqual(local_user["ident"], "1644629287")
+        self.assertEqual(local_user["origin_ident"], "1644629287")
         self.assertEqual(local_user["created"], 1644629287.028714)
         self.assertIsInstance(local_user["timing"], dict)
+        self.assertIsInstance(local_user['ident'], str)
 
         klat_user = parse_alert_context_from_message(test_message_klat_data)
         self.assertEqual(klat_user["user"], "server_user")

--- a/util/alert_manager.py
+++ b/util/alert_manager.py
@@ -287,9 +287,10 @@ class AlertManager:
         Add a timer to the GUI.
         :param alert: Timer to add to GUI
         """
-        self._active_gui_timers.append(alert)
-        self._active_gui_timers.sort(
-            key=lambda i: i.time_to_expiration.total_seconds())
+        if alert not in self._active_gui_timers:
+            self._active_gui_timers.append(alert)
+            self._active_gui_timers.sort(
+                key=lambda i: i.time_to_expiration.total_seconds())
 
     def dismiss_alert_from_gui(self, alert_id: str):
         """

--- a/util/parse_utils.py
+++ b/util/parse_utils.py
@@ -499,6 +499,7 @@ def parse_alert_context_from_message(message: Message) -> dict:
     required_context = {
         "user": message.context.get("user") or _DEFAULT_USER,
         "ident": str(uuid()),
+        "origin_ident": message.context.get('ident'),
         "created": message.context.get("timing",
                                        {}).get("handle_utterance") or time()
     }

--- a/util/parse_utils.py
+++ b/util/parse_utils.py
@@ -498,7 +498,7 @@ def parse_alert_context_from_message(message: Message) -> dict:
     """
     required_context = {
         "user": message.context.get("user") or _DEFAULT_USER,
-        "ident": message.context.get("ident") or str(uuid()),
+        "ident": str(uuid()),
         "created": message.context.get("timing",
                                        {}).get("handle_utterance") or time()
     }


### PR DESCRIPTION
Add unit tests for timers of the same name/time
Use `uuid` for alert idents to ensure unique alert IDs
Closes #59 