### PR TITLE
Fix bugs in Notification Handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -520,7 +520,7 @@ class AlertSkill(NeonSkill):
         # Cancel all alerts of some specified type
         if message.data.get("all"):
             for alert in alerts:
-                self.alert_manager.rm_alert(get_alert_id(alert))
+                self._dismiss_alert(get_alert_id(alert), alert.alert_type)
             self.speak_dialog("confirm_cancel_all",
                               {"kind": spoken_type},
                               private=True)
@@ -530,7 +530,6 @@ class AlertSkill(NeonSkill):
         if len(alerts) == 1:
             alert = alerts[0]
             self._dismiss_alert(get_alert_id(alert), alert.alert_type)
-            # self.alert_manager.rm_alert(get_alert_id(alert))
             self.speak_dialog('confirm_cancel_alert',
                               {'kind': spoken_type,
                                'name': alert.alert_name}, private=True)
@@ -548,7 +547,6 @@ class AlertSkill(NeonSkill):
 
         # Dismiss requested alert
         self._dismiss_alert(get_alert_id(alert), alert.alert_type)
-        # self.alert_manager.rm_alert(get_alert_id(alert))
         self.speak_dialog('confirm_cancel_alert',
                           {'kind': spoken_type,
                            'name': alert.alert_name}, private=True)

--- a/__init__.py
+++ b/__init__.py
@@ -196,6 +196,7 @@ class AlertSkill(NeonSkill):
         """
         LOG.debug("Updating homescreen widgets")
         time.sleep(3)
+        # TODO: Above sleep resolves missing widgets on start, find and fix
         self._update_homescreen(True, True)
 
     # Intent Handlers

--- a/__init__.py
+++ b/__init__.py
@@ -194,6 +194,8 @@ class AlertSkill(NeonSkill):
         """
         On ready, update the Home screen elements
         """
+        LOG.debug("Updating homescreen widgets")
+        time.sleep(3)
         self._update_homescreen(True, True)
 
     # Intent Handlers

--- a/__init__.py
+++ b/__init__.py
@@ -529,7 +529,8 @@ class AlertSkill(NeonSkill):
         # Only one candidate alert
         if len(alerts) == 1:
             alert = alerts[0]
-            self.alert_manager.rm_alert(get_alert_id(alert))
+            self._dismiss_alert(get_alert_id(alert), alert.alert_type)
+            # self.alert_manager.rm_alert(get_alert_id(alert))
             self.speak_dialog('confirm_cancel_alert',
                               {'kind': spoken_type,
                                'name': alert.alert_name}, private=True)
@@ -545,7 +546,9 @@ class AlertSkill(NeonSkill):
             self.speak_dialog("error_nothing_to_cancel", private=True)
             return
 
-        self.alert_manager.rm_alert(get_alert_id(alert))
+        # Dismiss requested alert
+        self._dismiss_alert(get_alert_id(alert), alert.alert_type)
+        # self.alert_manager.rm_alert(get_alert_id(alert))
         self.speak_dialog('confirm_cancel_alert',
                           {'kind': spoken_type,
                            'name': alert.alert_name}, private=True)
@@ -770,6 +773,7 @@ class AlertSkill(NeonSkill):
                            "action": "alerts.gui.show_timers"}
             message = Message("ovos.widgets.update",
                               {"type": "timer", "data": widget_data})
+            LOG.debug(f"Updating GUI timers with: {widget_data}")
             self.bus.emit(message)
         if do_alarms:
             alarms = [a for a in self.alert_manager.get_user_alerts()['pending']
@@ -778,6 +782,7 @@ class AlertSkill(NeonSkill):
                            "action": "alerts.gui.show_alarms"}
             message = Message("ovos.widgets.update",
                               {"type": "alarm", "data": widget_data})
+            LOG.debug(f"Updating GUI alarms with: {widget_data}")
             self.bus.emit(message)
 
     def _on_display_gui(self, message: Message):

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -536,6 +536,13 @@ class TestSkill(unittest.TestCase):
         self.skill.update_skill_settings = real_update_settings
 
     def test_handle_cancel_alert(self):
+        real_dismiss_from_gui = self.skill.alert_manager.dismiss_alert_from_gui
+        mock_dismiss_gui = Mock()
+        self.skill.alert_manager.dismiss_alert_from_gui = mock_dismiss_gui
+        real_update_homescreen = self.skill._update_homescreen
+        mock_update_homescreen = Mock()
+        self.skill._update_homescreen = mock_update_homescreen
+
         cancel_test_user = "test_user_cancellation"
         valid_context = {"username": cancel_test_user}
         tz = self.skill._get_user_tz()
@@ -574,8 +581,11 @@ class TestSkill(unittest.TestCase):
         message = Message("test", {"cancel": "cancel",
                                    "reminder": "reminder"}, valid_context)
         self.skill.handle_cancel_alert(message)
-        self.assertNotIn(get_alert_id(trash_reminder),
+        alert_id = get_alert_id(trash_reminder)
+        self.assertNotIn(alert_id,
                          self.skill.alert_manager.pending_alerts.keys())
+        mock_dismiss_gui.assert_called_with(alert_id)
+        mock_update_homescreen.assert_called_with(False, False)
         self.skill.speak_dialog.assert_called_with(
             "confirm_cancel_alert", {"kind": "reminder",
                                      "name": trash_reminder.alert_name},
@@ -610,7 +620,7 @@ class TestSkill(unittest.TestCase):
         self.assertEqual(pending,
                          self.skill.alert_manager.pending_alerts.keys())
 
-        # Cancel match name  pasta timer
+        # Cancel match name pasta timer
         message = Message("test",
                           {"cancel": "cancel",
                            "timer": "timer",
@@ -627,17 +637,20 @@ class TestSkill(unittest.TestCase):
                                    "end_token": 3
                                }
                            ]}, valid_context)
-        self.assertIn(get_alert_id(pasta_timer),
+        alert_id = get_alert_id(pasta_timer)
+        self.assertIn(alert_id,
                       self.skill.alert_manager.pending_alerts.keys())
         self.skill.handle_cancel_alert(message)
-        self.assertNotIn(get_alert_id(pasta_timer),
+        self.assertNotIn(alert_id,
                          self.skill.alert_manager.pending_alerts.keys())
         self.skill.speak_dialog.assert_called_with(
             "confirm_cancel_alert", {"kind": "timer",
                                      "name": pasta_timer.alert_name},
             private=True)
+        mock_dismiss_gui.assert_called_with(alert_id)
+        mock_update_homescreen.assert_called_with(True, False)
 
-        # Cancel match time  9:30 AM alarm
+        # Cancel match time 9:30 AM alarm
         message = Message("test",
                           {"cancel": "cancel",
                            "alarm": "alarm",
@@ -654,15 +667,18 @@ class TestSkill(unittest.TestCase):
                                    "end_token": 4
                                }
                            ]}, valid_context)
-        self.assertIn(get_alert_id(morning_alarm),
+        alert_id = get_alert_id(morning_alarm)
+        self.assertIn(alert_id,
                       self.skill.alert_manager.pending_alerts.keys())
         self.skill.handle_cancel_alert(message)
-        self.assertNotIn(get_alert_id(morning_alarm),
+        self.assertNotIn(alert_id,
                          self.skill.alert_manager.pending_alerts.keys())
         self.skill.speak_dialog.assert_called_with(
             "confirm_cancel_alert", {"kind": "alarm",
                                      "name": morning_alarm.alert_name},
             private=True)
+        mock_dismiss_gui.assert_called_with(alert_id)
+        mock_update_homescreen.assert_called_with(False, True)
 
         # Cancel partial name oven (cherry pie)
         message = Message("test",
@@ -681,15 +697,18 @@ class TestSkill(unittest.TestCase):
                                    "end_token": 3
                                }
                            ]}, valid_context)
-        self.assertIn(get_alert_id(oven_timer),
+        alert_id = get_alert_id(oven_timer)
+        self.assertIn(alert_id,
                       self.skill.alert_manager.pending_alerts.keys())
         self.skill.handle_cancel_alert(message)
-        self.assertNotIn(get_alert_id(oven_timer),
+        self.assertNotIn(alert_id,
                          self.skill.alert_manager.pending_alerts.keys())
         self.skill.speak_dialog.assert_called_with(
             "confirm_cancel_alert", {"kind": "timer",
                                      "name": oven_timer.alert_name},
             private=True)
+        mock_dismiss_gui.assert_called_with(alert_id)
+        mock_update_homescreen.assert_called_with(True, False)
 
         # Cancel all valid
         message = Message("test", {"cancel": "cancel",
@@ -708,6 +727,9 @@ class TestSkill(unittest.TestCase):
         self.skill.handle_cancel_alert(message)
         self.skill.speak_dialog.assert_called_with("error_nothing_to_cancel",
                                                    private=True)
+
+        self.skill.alert_manager.dismiss_alert_from_gui = real_dismiss_from_gui
+        self.skill._update_homescreen = real_update_homescreen
 
     def test_confirm_alert(self):
         # TODO

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -711,6 +711,7 @@ class TestSkill(unittest.TestCase):
         mock_update_homescreen.assert_called_with(True, False)
 
         # Cancel all valid
+        all_alerts = self.skill.alert_manager.get_user_alerts()['pending']
         message = Message("test", {"cancel": "cancel",
                                    "alert": "alert",
                                    "all": "all"}, valid_context)
@@ -722,6 +723,7 @@ class TestSkill(unittest.TestCase):
             self.skill.alert_manager.get_user_alerts(cancel_test_user),
             {"missed": list(), "active": list(), "pending": list()}
         )
+        mock_dismiss_gui.assert_has_calls(all_alerts, True)
 
         # Cancel all nothing to cancel
         self.skill.handle_cancel_alert(message)


### PR DESCRIPTION
# Description
Update "cancel_alert" intent handler to use `_dismiss_alert` instead of just removing the alert from the alert manager. This handles GUI/notification updates

# Issues
Closes #72
Closes #71

# Other Notes
This is tested to resolve #71 but only by adding an arbitrary sleep after `mycroft.ready`. In practice, this just means the homescreen might not show alert icons immediately, but the reason for having to wait should be found and fixed.