### PR TITLE
Update quiet_hours_start.dialog

### DIFF
--- a/locale/en-us/dialog/quiet_hours_start.dialog
+++ b/locale/en-us/dialog/quiet_hours_start.dialog
@@ -1,1 +1,1 @@
-Enabling quiet hours. I will not notify you of any alerts until you disable quiet hours.
+Enabling quiet hours. I will not notify you of any alerts until you end quiet hours.


### PR DESCRIPTION
# Description
Current confirmation dialogue implies that "disable quiet hours" would be a correct command, but this is not the case. "Disable" isn't in the existing vocabulary. "End quiet hours" is already a functional command, so I suggest we change this dialogue so that a user's natural response to it will be a functioning command. 