### PR TITLE
Update event handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -178,7 +178,7 @@ class AlertSkill(NeonSkill):
                                            self._alert_expired)
 
         # Update Homescreen UI models
-        self.add_event("mycroft.ready", self.on_ready, once=True)
+        self.add_event("mycroft.ready", self.on_ready)
 
         self.add_event("neon.get_events", self._get_events)
         self.add_event("alerts.gui.dismiss_notification",


### PR DESCRIPTION
# Description
Remove `once` from `mycroft.ready` handling so all skills handle ready events

# Issues
Related to https://github.com/OpenVoiceOS/ovos-utils/issues/172

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->